### PR TITLE
Fixed ConvertFrom-RTDate's date handling

### DIFF
--- a/PSRT/Private/ConvertFrom-RTDate.ps1
+++ b/PSRT/Private/ConvertFrom-RTDate.ps1
@@ -9,7 +9,7 @@
     #>
     param($DateString)
     $Date = $DateString -split '\s'
-    $Month = switch ($x)
+    $Month = switch ($Date[1])
              {
                  'jan' {1}
                  'feb' {2}
@@ -26,8 +26,7 @@
                  default {(Get-Date).Month}
              }
     $Day = $Date[2]
-    $Hour = ( $Date[3] -split ':')[0]
-    $Minute = ( $Date[3] -split ':')[1]
+    $Hour, $Minute, $Second = $Date[3] -split ':'
     $Year = $Date[4]
-    Get-Date -Year $Year -Month $Month -Day $Day -Hour $Hour -Minute $Minute
+    Get-Date -Year $Year -Month $Month -Day $Day -Hour $Hour -Minute $Minute -Second $Second
 }


### PR DESCRIPTION
Thanks for working on this! This looks to be very useful.

Unless I am missing something $x in the switch statement was never defined and therefore always $null. I replaced it with $Date[1] which should correspond to the month. I also included the seconds in the Get-Date statement since otherwise it was always using the current time's value for the seconds.