### PR TITLE
Enabled UseBasicParsing switch.

### DIFF
--- a/PSRT/Public/Find-RTTicket.ps1
+++ b/PSRT/Public/Find-RTTicket.ps1
@@ -48,7 +48,7 @@ Function Find-RTTicket {
         [string]$BaseUri = $PSRTConfig.BaseUri,
         [switch]$Raw
     )
-    $InvokeParams = @{ WebSession = $Session }
+    $InvokeParams = @{ WebSession = $Session; UseBasicParsing = $true }
     if($Referer)
     {
         $headers = @{}

--- a/PSRT/Public/Get-RTTicket.ps1
+++ b/PSRT/Public/Get-RTTicket.ps1
@@ -33,7 +33,7 @@ Function Get-RTTicket {
     )
     $Ticket = $Ticket.TrimStart('#').TrimStart('RT')
     $uri = Join-Parts -Separator '/' -Parts $BaseUri, "REST/1.0/ticket/$Ticket"
-    $Response = ( Invoke-WebRequest -Uri $uri -WebSession $Session ).Content
+    $Response = ( Invoke-WebRequest -Uri $uri -WebSession $Session -UseBasicParsing ).Content
     if($Raw)
     {
         $Response

--- a/PSRT/Public/Get-RTTicketEntry.ps1
+++ b/PSRT/Public/Get-RTTicketEntry.ps1
@@ -38,7 +38,7 @@ Function Get-RTTicketEntry {
     )
     $Ticket = $Ticket.TrimStart('#').TrimStart('RT')
     $uri = Join-Parts -Separator '/' -Parts $BaseUri, "REST/1.0/ticket/$Ticket/history/id/$Entry"
-    $Response = ( Invoke-WebRequest -Uri $uri -WebSession $Session ).Content
+    $Response = ( Invoke-WebRequest -Uri $uri -WebSession $Session -UseBasicParsing ).Content
     if($Raw)
     {
         $Response

--- a/PSRT/Public/New-RTSession.ps1
+++ b/PSRT/Public/New-RTSession.ps1
@@ -39,13 +39,12 @@ function New-RTSession {
         [switch]$DontUpdateConfig
     )
     Write-Verbose "Creating RT Session"
-    $r = Invoke-WebRequest -Uri $BaseUri -SessionVariable RTSession -Credential $Credential
-    $form = $r.Forms[0]
-    $form.fields['user'] = $Credential.UserName
-    $form.fields['pass'] = $Credential.GetNetworkCredential().Password
-    Write-Verbose "Sending RT Session credentials for [$($Credential.UserName)]"
-    $r = Invoke-WebRequest -Uri "$BaseUri$($Form.Action)" -WebSession $RTSession -Method POST -Body $form.Fields
+    $EncodedUserName = [System.Web.HttpUtility]::UrlEncode($Credential.UserName)
+    $EncodedPassword = [System.Web.HttpUtility]::UrlEncode($Credential.GetNetworkCredential().Password)
+    Write-Verbose -Message "Sending RT Session credentials for $($Credential.UserName)"
+    $r = Invoke-WebRequest -Uri $BaseUri -SessionVariable RTSession -Method Post -UseBasicParsing -Body "user=$EncodedUserName&pass=$EncodedPassword"
     if ($r.Content -notmatch "<li>Your username or password is incorrect</li>") {
+        Write-Verbose -Message "Authentication Successful"
         if(-not $DontUpdateConfig)
         {
             Set-RTConfig -Session $RTSession

--- a/PSRT/Public/New-RTTicket.ps1
+++ b/PSRT/Public/New-RTTicket.ps1
@@ -82,7 +82,7 @@ Function New-RTTicket {
         [string]$BaseUri = $PSRTConfig.BaseUri,
         [switch]$Raw
     )
-    $InvokeParams = @{ WebSession = $Session }
+    $InvokeParams = @{ WebSession = $Session; UseBasicParsing = $true }
     if($Referer)
     {
         $headers = @{}

--- a/PSRT/Public/Set-RTTicket.ps1
+++ b/PSRT/Public/Set-RTTicket.ps1
@@ -79,7 +79,7 @@
     )
     Process
     {
-        $InvokeParams = @{ WebSession = $Session }
+        $InvokeParams = @{ WebSession = $Session; UseBasicParsing = $true }
         if($Referer)
         {
             $headers = @{}


### PR DESCRIPTION
Added the UseBasicParsing switch to all instances of Invoke-WebRequest. This necessitated changing the login process in New-RTSession

This is a change that may not benefit many people besides me but it is necessary in my environment because the account I run PowerShell as does not have access to Internet Explorer. Using the UseBasicParsing switch works around that. It may be a little lighter weight way of doing it and Invoke-WebRequest is only called once in the updated login process.