### PR TITLE
Support web calls

### DIFF
--- a/PSRT/Public/New-RTSession.ps1
+++ b/PSRT/Public/New-RTSession.ps1
@@ -39,7 +39,6 @@ function New-RTSession {
         [switch]$DontUpdateConfig
     )
     Add-Type -AssemblyName System.Web
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     Write-Verbose "Creating RT Session"
     $EncodedUserName = [System.Web.HttpUtility]::UrlEncode($Credential.UserName)
     $EncodedPassword = [System.Web.HttpUtility]::UrlEncode($Credential.GetNetworkCredential().Password)

--- a/PSRT/Public/New-RTSession.ps1
+++ b/PSRT/Public/New-RTSession.ps1
@@ -38,6 +38,8 @@ function New-RTSession {
 
         [switch]$DontUpdateConfig
     )
+    Add-Type -AssemblyName System.Web
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     Write-Verbose "Creating RT Session"
     $EncodedUserName = [System.Web.HttpUtility]::UrlEncode($Credential.UserName)
     $EncodedPassword = [System.Web.HttpUtility]::UrlEncode($Credential.GetNetworkCredential().Password)


### PR DESCRIPTION
System.Web.HttpUtility type accelerator no longer works without explicitly adding the System.Web type in advance, so I've added that call.
Additionally, fixed invoke-webrequest not working against an RT server with TLS 1.2.