### PR TITLE
Fix web issues

### DIFF
--- a/PSRT/Public/Find-RTTicket.ps1
+++ b/PSRT/Public/Find-RTTicket.ps1
@@ -48,6 +48,8 @@ Function Find-RTTicket {
         [string]$BaseUri = $PSRTConfig.BaseUri,
         [switch]$Raw
     )
+    Add-Type -AssemblyName System.Web
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     $InvokeParams = @{ WebSession = $Session; UseBasicParsing = $true }
     if($Referer)
     {

--- a/PSRT/Public/Find-RTTicket.ps1
+++ b/PSRT/Public/Find-RTTicket.ps1
@@ -49,7 +49,6 @@ Function Find-RTTicket {
         [switch]$Raw
     )
     Add-Type -AssemblyName System.Web
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
     $InvokeParams = @{ WebSession = $Session; UseBasicParsing = $true }
     if($Referer)
     {


### PR DESCRIPTION
System.Web.HttpUtility type accelerator no longer works without explicitly adding the System.Web type in advance, so I've added that call.
Additionally, fixed invoke-webrequest not working against an RT server with TLS 1.2.